### PR TITLE
Docker Compose for Postgres+API+Web and container-ready dev config

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,34 @@
+FROM elixir:1.17-alpine AS build
+
+RUN apk add --no-cache build-base git
+
+WORKDIR /app
+
+RUN mix do local.hex --force, local.rebar --force
+
+COPY mix.exs mix.lock ./
+COPY config config
+RUN mix deps.get --only dev
+RUN MIX_ENV=dev mix deps.compile
+
+COPY lib lib
+COPY priv priv
+
+RUN MIX_ENV=dev mix compile
+
+FROM elixir:1.17-alpine
+
+RUN apk add --no-cache postgresql-client
+
+WORKDIR /app
+ENV MIX_ENV=dev
+
+COPY --from=build /app /app
+
+COPY --from=build /root/.mix /root/.mix
+
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 4000
+CMD ["/entrypoint.sh"]

--- a/api/config/dev.exs
+++ b/api/config/dev.exs
@@ -2,13 +2,10 @@ import Config
 
 # Configure your database
 config :api, Api.Repo,
-  username: "postgres",
-  password: "postgres",
-  hostname: "localhost",
-  database: "api_dev",
-  stacktrace: true,
+  url: System.get_env("DATABASE_URL", "ecto://postgres:postgres@db:5432/api_dev"),
+  pool_size: String.to_integer(System.get_env("POOL_SIZE", "10")),
   show_sensitive_data_on_connection_error: true,
-  pool_size: 10
+  stacktrace: true
 
 # For development, we disable any cache and enable
 # debugging and code reloading.
@@ -19,7 +16,7 @@ config :api, Api.Repo,
 config :api, ApiWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
-  http: [ip: {127, 0, 0, 1}, port: String.to_integer(System.get_env("PORT") || "4000")],
+  http: [ip: {0, 0, 0, 0}, port: String.to_integer(System.get_env("PORT") || "4000")],
   thousand_island_options: [
     read_timeout: 60_000,   # time to read request body/headers
     idle_timeout: 120_000   # keep-alive idle timeout
@@ -27,6 +24,7 @@ config :api, ApiWeb.Endpoint,
   check_origin: false,
   code_reloader: true,
   debug_errors: true,
+  server: true,
   secret_key_base: "HM0UhN47rXf9MjvfcAnhNZu1B9CkOHxwE95vlT0RtyOziOfQuokT4Epmq9bl+Xas",
   watchers: []
 

--- a/api/docker/entrypoint.sh
+++ b/api/docker/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+echo "Waiting for Postgres at $DB_HOST:$DB_PORT..."
+until pg_isready -h "${DB_HOST:-db}" -p "${DB_PORT:-5432}" -U "${DB_USER:-postgres}" >/dev/null 2>&1; do
+  sleep 1
+done
+echo "Postgres is ready."
+
+mix ecto.create || true
+mix ecto.migrate || true
+
+exec mix phx.server
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,78 @@
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: soclone_db
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB} -h 127.0.0.1",
+        ]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  ollama:
+    image: ollama/ollama:latest
+    container_name: soclone_ollama
+    ports:
+      - "11434:11434"
+    environment:
+      OLLAMA_HOST: 0.0.0.0
+      OLLAMA_KEEP_ALIVE: 5m
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 25s
+
+  api:
+    build:
+      context: ./api
+      dockerfile: Dockerfile
+    container_name: soclone_api
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      PHX_PORT: ${PHX_PORT}
+      PHX_SERVER: "true"
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      LLM_API_BASE: ${LLM_API_BASE}
+      LLM_MODEL: ${LLM_MODEL}
+      POSTGRES_USER: ${POSTGRES_USER}
+      DB_HOST: db
+      DB_PORT: "5432"
+      DB_USER: postgres
+    ports:
+      - "${PHX_PORT}:4000"
+    depends_on:
+      db:
+        condition: service_healthy
+      ollama:
+        condition: service_started
+
+  web:
+    build:
+      context: ./web/frontend
+      dockerfile: Dockerfile
+    container_name: soclone_web
+    ports:
+      - "${WEB_PORT}:5173"
+    depends_on:
+      - api
+    environment:
+      VITE_API_BASE: "http://localhost:${PHX_PORT}"
+
+volumes:
+  db_data:
+  ollama_data:

--- a/web/frontend/Dockerfile
+++ b/web/frontend/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20-alpine
+
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]


### PR DESCRIPTION
## Summary
Adds a composable container setup and aligns API dev config for containerized dev:
- docker-compose.yml: postgres, phoenix api (:4000), web (:5173)
- api/Dockerfile and web/frontend/Dockerfile for dev
- api/config/dev.exs: bind to 0.0.0.0, DB URL defaults to service `db`, relaxed timeouts

## How to Test
```bash
docker compose up --build
docker compose up -d db ollama
docker inspect --format='{{.State.Health.Status}}' soclone_db
docker inspect --format='{{.State.Health.Status}}' soclone_ollama
docker compose exec ollama ollama pull llama3:8b
docker compose exec ollama ollama list
docker compose up -d api web

# then:
curl "http://localhost:4000/api/search?q=phoenix liveview form"
open http://localhost:5173
